### PR TITLE
Fix for null data being passed when making a request

### DIFF
--- a/src/ZiggeoConnect.cs
+++ b/src/ZiggeoConnect.cs
@@ -17,8 +17,10 @@ public class ZiggeoConnect {
     public Stream request(string method, string path, Dictionary<string, string> data, string file)
     {
         string postData = "";
-        foreach (string key in data.Keys)
-            postData += key + "=" + data[key] + "&";
+        if (data != null) {
+            foreach (string key in data.Keys)
+                postData += key + "=" + data[key] + "&";
+        }
         string uri = this.application.config().server_api_url + "/v1" + path;
         if (method != "POST")
             uri += "?" + postData;


### PR DESCRIPTION
When calling the request method, the dictionary can be null in some circumstances, this is to guard against this, an exception is thrown for instance when I call

ziggeo.videos().delete(_token_);
